### PR TITLE
fix: typo in index variable

### DIFF
--- a/utils/misc.py
+++ b/utils/misc.py
@@ -156,7 +156,7 @@ def save_batch_imgs(name, vis_batch, save_dir):
 def save_img_dir(out, vis_batch):
     os.makedirs(out, exist_ok=True)
     for i in range(len(vis_batch)):
-        path = f"{out}/{j:05d}.png"
+        path = f"{out}/{i:05d}.png"
         imageio.imwrite(path, vis_batch[i])
 
 


### PR DESCRIPTION
Thank you very much for making the code available. I noticed a small typo in `utils.misc.save_img_dir` (`i` instead of `j`), this PR fixes it.